### PR TITLE
Add new requirement to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Project is using cmake (>=2.8.8) build system.
 
 * Install prerequisites.
 ```
-    $ sudo apt-get install cmake pkg-config ragel libasound2-dev            \
+    $ sudo apt-get install cmake pkg-config ragel libasound2-dev libssl-dev \
            libglib2.0-dev libconfig-dev libpango1.0-dev libgl1-mesa-dev     \
            libevent-dev libgtk+2.0-dev libgles2-mesa-dev libxrandr-dev g++
 ```


### PR DESCRIPTION
Due to commit: 56de5b57a71cde7fcfd623594c67597092f4a6ac
I found that this needed to be a prerequisite to compile since I didn't have it already.
Source: https://stackoverflow.com/questions/16248775/cmake-not-able-to-find-openssl