### PR TITLE
Compatibility squeeze

### DIFF
--- a/src/compat.c
+++ b/src/compat.c
@@ -42,3 +42,15 @@ g_async_queue_timeout_pop_compat(GAsyncQueue *queue, guint64 timeout)
     return g_async_queue_timed_pop(queue, &end_time);
 #endif
 }
+
+void
+g_list_free_full_compat (GList *list, GDestroyNotify free_func)
+{
+#if (VER(GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION) >= VER(2, 28))
+   return g_list_free_full (list, free_func);
+#else
+   g_list_foreach (list, (GFunc) free_func, NULL);
+   g_list_free (list);
+#endif
+}
+

--- a/src/compat.h
+++ b/src/compat.h
@@ -44,5 +44,7 @@
 gpointer
 g_async_queue_timeout_pop_compat(GAsyncQueue *queue, guint64 timeout);
 
+void
+g_list_free_full_compat (GList *list, GDestroyNotify free_func);
 
 #endif // FPP_COMPAT_H

--- a/src/uri_parser/uri_parser.c
+++ b/src/uri_parser/uri_parser.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <glib.h>
+#include "../compat.h"
 
 
 typedef struct {
@@ -300,7 +301,7 @@ uri_parser_merge_uris(const char *base_uri, const char *rel_uri)
         fragment.len, fragment.data);
 
     // free temporary strings
-    g_list_free_full(m, g_free);
+    g_list_free_full_compat(m, g_free);
 
     return res;
 }


### PR DESCRIPTION
The function g_list_free_full exists only since glib 2.28 so we cannot build for squeeze. Here the fix to build on Debian Squeeze.