### PR TITLE
Use PulseAudio find module instead of pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,10 @@ pkg_check_modules(REQ
     openssl
     REQUIRED)
 
-pkg_check_modules(PULSEAUDIO libpulse)
+find_package(PulseAudio)
 
-if (${PULSEAUDIO_FOUND})
+if (PULSEAUDIO_FOUND)
     add_definitions(-DHAVE_PULSEAUDIO=1)
-    set(HAVE_PULSEAUDIO 1)
 endif()
 
 include_directories(${REQ_INCLUDE_DIRS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,7 @@ set(source_list
     screensaver_control.c
 )
 
-if (${HAVE_PULSEAUDIO})
+if (PULSEAUDIO_FOUND)
     list(APPEND source_list audio_thread_pulseaudio.c)
 endif()
 
@@ -96,13 +96,12 @@ add_library(freshwrapper-pepperflash SHARED
 
 link_directories(
     ${REQ_LIBRARY_DIRS}
-    ${PULSEAUDIO_LIBRARY_DIRS}
 )
 
 target_link_libraries(freshwrapper-pepperflash
     dl
     ${REQ_LIBRARIES}
-    ${PULSEAUDIO_LIBRARIES}
+    ${PULSEAUDIO_LIBRARY}
 )
 
 # target_link_libraries(freshwrapper-nacl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,6 @@ set(test_list
 
 link_directories(
     ${REQ_LIBRARY_DIRS}
-    ${PULSEAUDIO_LIBRARY_DIRS}
 )
 
 # simplify inclusion of .c sources
@@ -32,7 +31,7 @@ foreach(item ${test_list})
         "-Wl,-z,muldefs"
         dl
         ${REQ_LIBRARIES}
-        ${PULSEAUDIO_LIBRARIES})
+        ${PULSEAUDIO_LIBRARY})
     add_test(${item} ${item})
     add_dependencies(check ${item})
 endforeach()


### PR DESCRIPTION
PulseAudio comes with its own find module, which should be prefered over using pkg-config.
Additionaly, this makes it possible to disable PulseAudio even when it's present on the system, simply by doing:

cmake -DCMAKE_DISABLE_FIND_PACKAGE_PulseAudio=1 ..