### PR TITLE
get back to the pkg_check_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,14 @@ pkg_check_modules(REQ
     openssl
     REQUIRED)
 
-find_package(PulseAudio QUIET)
+pkg_check_modules(PulseAudio libpulse)
 
-if (PULSEAUDIO_FOUND)
+if(${PULSEAUDIO_FOUND})
     add_definitions(-DHAVE_PULSEAUDIO=1)
     message(STATUS "  found PulseAudio ${PULSEAUDIO_VERSION} (optional)")
-else()
+elseif(NOT ${PULSEAUDIO_FOUND})
     message(STATUS "  no PulseAudio found (optional)")
-endif()
+endif(${PULSEAUDIO_FOUND})
 
 include_directories(${REQ_INCLUDE_DIRS})
 add_definitions(${REQ_CFLAGS_OTHER})


### PR DESCRIPTION
Apparentely the find_package call fails to found the PulseAudio in some systems like debian, and the if/else conditionals was failing until i put the ${PULSEAUDIO_FOUND} in the argument. 
So i saw 2 ways to solve this problem, one was to make  a .cmake file with some configuration that allows cmake to found the PulseAudio libraries, or get back to the pkg_check_modules. the simplest way that i saw was getting back to pkg_check_modules.

And the conditionals were not working until i add the "${PULSEAUDIO_FOUND}" argument to the conditionals, i'm not really sure why, because it supposed to work on either of those two ways. but doing this the PulseAudio recognition was solved for me.

it's not much, but i hope it helps a bit.