### PR TITLE
Fix ‘av_frame_alloc’, ‘av_frame_free’ and ‘avcodec_free_context’ dete…

### DIFF
--- a/cmake/ffmpeg-compat/CMakeLists.txt
+++ b/cmake/ffmpeg-compat/CMakeLists.txt
@@ -28,6 +28,7 @@ MACRO_C_SOURCE_CHECK(cfg_av_pix_fmt_vdpau.c HAVE_AV_PIX_FMT_VDPAU)
 MACRO_C_SOURCE_CHECK(cfg_avcodecid.c HAVE_AVCodecID)
 MACRO_C_SOURCE_CHECK(cfg_avcodeccontext_get_buffer2.c HAVE_AVCodecContext_get_buffer2)
 
+list(APPEND CMAKE_REQUIRED_INCLUDES ${HWDEC_libavcodec_INCLUDEDIR})
 MACRO_SYMBOL_CHECK(av_frame_alloc "libavcodec/avcodec.h" HAVE_av_frame_alloc)
 MACRO_SYMBOL_CHECK(av_frame_free "libavcodec/avcodec.h" HAVE_av_frame_free)
 MACRO_SYMBOL_CHECK(avcodec_free_context "libavcodec/avcodec.h" HAVE_avcodec_free_context)


### PR DESCRIPTION
Fix ‘av_frame_alloc’, ‘av_frame_free’ and ‘avcodec_free_context’ detection on Fedora 21

```
On Fedora 21, trying to build the latest version results in 
/home/francois/Downloads/freshplayerplugin/src/ppb_video_decoder.c:58:1: error: static declaration of ‘av_frame_alloc’ follows non-static declaration
 av_frame_alloc(void)
 ^
In file included from /usr/include/ffmpeg/libavcodec/avcodec.h:38:0,
                 from /home/francois/Downloads/freshplayerplugin/src/pp_resource.h:68,
                 from /home/francois/Downloads/freshplayerplugin/src/tables.h:31,
                 from /home/francois/Downloads/freshplayerplugin/src/ppb_video_decoder.c:29:
/usr/include/ffmpeg/libavutil/frame.h:602:10: note: previous declaration of ‘av_frame_alloc’ was here
 AVFrame *av_frame_alloc(void);
          ^
```
and other similar errors