### PR TITLE
By default absent the pepperflash_path option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ Project is using cmake (>=2.8.8) build system.
 ```
 
 * Put generated `libfreshwrapper-flashplayer.so` into browser plugins directory (`~/.mozilla/plugins`)
-  or instal system-wise by calling:
+  or install system-wide by calling:
 ```
     # make install
 ```
 
-By default `make install` will put plugin(s) to `${CMAKE_INSTALL_PREFIX}/lib/mozilla/plugins`. The
+By default `make install` will put plugin(s) to `${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/mozilla/plugins`. The
 path could be changed either by changing CMake parameter `CMAKE_INSTALL_PREFIX`, or by setting
 `MOZPLUGIN_INSTALL_DIR`.
 

--- a/data/freshwrapper.conf.example
+++ b/data/freshwrapper.conf.example
@@ -34,10 +34,10 @@ jack_autostart_server = 1
 
 # Path to the Pepper Flash plugin.
 # If the option is absent, freshwrapper will search for Pepper Flash in
-# a number of location where it could be. Usually that's enough, but if
+# a number of locations where it could be. Usually that's enough, but if
 # not, you should manually enter the right path. Multiple paths could
 # be specified, separated by colon.
-pepperflash_path = "/opt/google/chrome/PepperFlash/libpepflashplayer.so"
+#pepperflash_path = "/opt/google/chrome/PepperFlash/libpepflashplayer.so"
 
 # "Command-line" arguments for Flash
 flash_command_line = "enable_hw_video_decode=1,enable_stagevideo_auto=1"


### PR DESCRIPTION
By default, absent the pepperflash_path option, make works out of the box with google-chrome-beta.
Also review some text ... 