### PR TITLE
Call tables_open_display() after config initialization

### DIFF
--- a/src/np_entry.c
+++ b/src/np_entry.c
@@ -449,15 +449,15 @@ NP_Initialize(NPNetscapeFuncs *aNPNFuncs, NPPluginFuncs *aNPPFuncs)
 
     memcpy(aNPPFuncs, &pf, pf.size);
 
-    if (tables_open_display() != 0)
-        return NPERR_GENERIC_ERROR;
-
     if (aNPNFuncs->version < NPVERS_HAS_PLUGIN_THREAD_ASYNC_CALL) {
         config.quirks.plugin_missing = 1;
         config.quirks.incompatible_npapi_version = 1;
     }
 
     load_ppp_module();
+
+    if (tables_open_display() != 0)
+        return NPERR_GENERIC_ERROR;
 
     int res = call_plugin_init_module();
     if (res != 0) {


### PR DESCRIPTION
'cause otherwise we're getting zeros in config parameters inside
tables_open_display() instead of actual values and can't enable hardware video decoding.