### PR TITLE
Fix typos

### DIFF
--- a/3rdparty/angle/src/compiler/translator/InfoSink.cpp
+++ b/3rdparty/angle/src/compiler/translator/InfoSink.cpp
@@ -26,7 +26,7 @@ void TInfoSinkBase::prefix(TPrefixType p) {
             sink.append("NOTE: ");
             break;
         default:
-            sink.append("UNKOWN ERROR: ");
+            sink.append("UNKNOWN ERROR: ");
             break;
     }
 }

--- a/3rdparty/angle/src/compiler/translator/InitializeDll.cpp
+++ b/3rdparty/angle/src/compiler/translator/InitializeDll.cpp
@@ -16,12 +16,12 @@
 bool InitProcess()
 {
     if (!InitializePoolIndex()) {
-        assert(0 && "InitProcess(): Failed to initalize global pool");
+        assert(0 && "InitProcess(): Failed to initialize global pool");
         return false;
     }
 
     if (!InitializeParseContextIndex()) {
-        assert(0 && "InitProcess(): Failed to initalize parse context");
+        assert(0 && "InitProcess(): Failed to initialize parse context");
         return false;
     }
 


### PR DESCRIPTION
Typos were found by the lintian tool while compiling this project on Debian.

These typos appear into the generated binaries.