### PR TITLE
add Adobe's package paths to default path list

### DIFF
--- a/src/config_pepperflash.c
+++ b/src/config_pepperflash.c
@@ -29,6 +29,8 @@ const char *pepperflash_path_list[] = {
     "/opt/google/chrome/PepperFlash",           // Chrome
     "/opt/google/chrome-beta/PepperFlash",      // Chrome beta
     "/opt/google/chrome-unstable/PepperFlash",  // Chrome unstable
+    "/usr/lib/flash-plugin",                    // Adobe package
+    "/usr/lib64/flash-plugin",                  // Adobe package
     "/usr/lib/adobe-flashplugin",               // adobe-flashplugin (Ubuntu)
     "/usr/lib/pepperflashplugin-nonfree",       // pepperflashplugin-nonfree (Debian)
     "/usr/lib/PepperFlash",                     // chromium-pepperflash-plugin (Slackware)


### PR DESCRIPTION
This PR simply adds the paths from Adobe's official packages (that can be downloaded at [get.adobe.com/flashplayer/otherversions/](https://get.adobe.com/flashplayer/otherversions/)). I think it could be a very common path for `libpepflashplayer.so` as it's used in the RPM package distributed by Adobe.